### PR TITLE
Provide more detailed phi information in the ROverZ histograms

### DIFF
--- a/extract_data.cxx
+++ b/extract_data.cxx
@@ -192,6 +192,7 @@ int main(){
   TTree * tree = (TTree*)file->Get("HGCalTriggerNtuple");
 
   bool createFlatFile = false;
+  int nPhiBins = 12;
   
   // Declaration of leaf types
   std::vector<int>     *tc_layer = 0;
@@ -250,7 +251,7 @@ int main(){
 
     //R/Z Histograms
 
-    TH2D * ROverZ_Inclusive = new TH2D("ROverZ_Inclusive","",42,0.076,0.58,12,0,2*M_PI/3);
+    TH2D * ROverZ_Inclusive = new TH2D("ROverZ_Inclusive","",42,0.076,0.58,nPhiBins,0,2*M_PI/3);
     std::map<std::tuple<int,int,int,int>,TH2D*> ROverZ_per_module;
     //Create one for each module (silicon at first)
     for ( int i = 0; i < 15; i++){//u
@@ -258,7 +259,7 @@ int main(){
 	for ( int k = 1; k < 53; k++){//layer
 
 	  if ( k < 28 && k%2 == 0 ) continue;
-	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH2D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,12,0,2*M_PI/3);
+	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH2D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,nPhiBins,0,2*M_PI/3);
 	}
       }
     }
@@ -267,7 +268,7 @@ int main(){
       for ( int j = 0; j < 12; j++){
 	for ( int k = 37; k < 53; k++){
 
-	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH2D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,12,0,2*M_PI/3);
+	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH2D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,nPhiBins,0,2*M_PI/3);
 
 	}
       }

--- a/extract_data.cxx
+++ b/extract_data.cxx
@@ -175,7 +175,7 @@ int main(){
   // TString flat_file_silicon = "words_all_v11_silicon.txt";
   // TString flat_file_scintillator = "words_all_v11_scintillator.txt";
 
-  TString input_file = "../small_v11_neutrino_gun_200415.root.root";
+  TString input_file = "../small_v11_neutrino_gun_200415.root";
   TString flat_file_silicon = "words_all_v11_silicon_neutrino_gun.txt";
   TString flat_file_scintillator = "words_all_v11_scintillator_neutrino_gun.txt";
 
@@ -191,7 +191,7 @@ int main(){
   TFile * file = new TFile(input_file,"READ");
   TTree * tree = (TTree*)file->Get("HGCalTriggerNtuple");
 
-  bool createFlatFile = true;
+  bool createFlatFile = false;
   
   // Declaration of leaf types
   std::vector<int>     *tc_layer = 0;
@@ -250,18 +250,18 @@ int main(){
 
     //R/Z Histograms
 
-    TH1D * ROverZ_Inclusive = new TH1D("ROverZ_Inclusive","",42,0.076,0.58);
-    TH1D * ROverZ_Inclusive_Phi60 = new TH1D("ROverZ_Inclusive_Phi60","",42,0.076,0.58);
-    std::map<std::tuple<int,int,int,int>,TH1D*> ROverZ_per_module;
-    std::map<std::tuple<int,int,int,int>,TH1D*> ROverZ_per_module_Phi60;
+    TH2D * ROverZ_Inclusive = new TH2D("ROverZ_Inclusive","",42,0.076,0.58,12,0,2*M_PI/3);
+    //TH1D * ROverZ_Inclusive_Phi60 = new TH1D("ROverZ_Inclusive_Phi60","",42,0.076,0.58);
+    std::map<std::tuple<int,int,int,int>,TH2D*> ROverZ_per_module;
+    //std::map<std::tuple<int,int,int,int>,TH1D*> ROverZ_per_module_Phi60;
     //Create one for each module (silicon at first)
     for ( int i = 0; i < 15; i++){//u
       for ( int j = 0; j < 15; j++){//v
 	for ( int k = 1; k < 53; k++){//layer
 
 	  if ( k < 28 && k%2 == 0 ) continue;
-	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH1D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
-	  ROverZ_per_module_Phi60[std::make_tuple(0,i,j,k)] = new TH1D( ("ROverZ_Phi60_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
+	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH2D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,12,0,2*M_PI/3);
+	  //ROverZ_per_module_Phi60[std::make_tuple(0,i,j,k)] = new TH1D( ("ROverZ_Phi60_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
 	  
 	}
       }
@@ -271,8 +271,8 @@ int main(){
       for ( int j = 0; j < 12; j++){
 	for ( int k = 37; k < 53; k++){
 
-	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH1D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
-	  ROverZ_per_module_Phi60[std::make_tuple(1,i,j,k)] = new TH1D( ("ROverZ_Phi60_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
+	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH2D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,12,0,2*M_PI/3);
+	  //ROverZ_per_module_Phi60[std::make_tuple(1,i,j,k)] = new TH1D( ("ROverZ_Phi60_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
 
 	}
       }
@@ -294,7 +294,7 @@ int main(){
     for (Long64_t jentry=0; jentry<nentries;jentry++) {
       nb = tree->GetEntry(jentry);   
       if (jentry % 100 == 0) std::cout << jentry << " / " << nentries << std::endl;;
-      //      if (jentry > 100 )break;
+      //if (jentry > 100 )break;
 
       for (int j = 0;j<tc_waferu->size();j++){
 
@@ -304,9 +304,9 @@ int main(){
 	//Fill Eta Histograms	
 	std::pair<float,float> eta_phi = getROverZPhi(tc_x->at(j),tc_y->at(j),tc_z->at(j));
 	
-	ROverZ_Inclusive->Fill(std::abs(eta_phi.first));
-	if ( eta_phi.second < M_PI/3 )
-	  ROverZ_Inclusive_Phi60->Fill(std::abs(eta_phi.first));
+	ROverZ_Inclusive->Fill(std::abs(eta_phi.first),eta_phi.second);
+	// if ( eta_phi.second < M_PI/3 )
+	//   ROverZ_Inclusive_Phi60->Fill(std::abs(eta_phi.first));
 
 	
 	if ( u > -990 ){//Silicon
@@ -321,9 +321,9 @@ int main(){
 	  }
 
 
-	  ROverZ_per_module[std::make_tuple(0,uv.first,uv.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
-	  if ( eta_phi.second < M_PI/3 )
-	    ROverZ_per_module_Phi60[std::make_tuple(0,uv.first,uv.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
+	  ROverZ_per_module[std::make_tuple(0,uv.first,uv.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first),eta_phi.second);
+	  // if ( eta_phi.second < M_PI/3 )
+	  //   ROverZ_per_module_Phi60[std::make_tuple(0,uv.first,uv.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
 	      
 	  
 	}
@@ -341,9 +341,9 @@ int main(){
 	  }
 
 
-	  ROverZ_per_module[std::make_tuple(1,etaphi.first,etaphi.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
-	  if ( eta_phi.second < M_PI/3 )
-	    ROverZ_per_module_Phi60[std::make_tuple(1,etaphi.first,etaphi.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
+	  ROverZ_per_module[std::make_tuple(1,etaphi.first,etaphi.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first),eta_phi.second);
+	  // if ( eta_phi.second < M_PI/3 )
+	  //   ROverZ_per_module_Phi60[std::make_tuple(1,etaphi.first,etaphi.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
 
 
 
@@ -462,14 +462,14 @@ int main(){
     TFile * file_out = new TFile("ROverZHistograms.root","RECREATE");
     file_out->cd();
     ROverZ_Inclusive->Write();
-    ROverZ_Inclusive_Phi60->Write();
+    //    ROverZ_Inclusive_Phi60->Write();
 
     for (auto& x: ROverZ_per_module) {
       x.second->Write();
     }
-    for (auto& x: ROverZ_per_module_Phi60) {
-      x.second->Write();
-    }
+    // for (auto& x: ROverZ_per_module_Phi60) {
+    //   x.second->Write();
+    // }
 
     file_out->Close();
     //out_words->SaveAs("hist.root");

--- a/extract_data.cxx
+++ b/extract_data.cxx
@@ -181,11 +181,7 @@ int main(){
 
   //TFile * file = new TFile("data/PU200-V11-TTBAR-2.root","READ");
   //TFile * file = new TFile("data/PU200-QG.root","READ");
-  //TFile * file = new TFile("data/PU200-3.root","READ");
   //  TFile * file = new TFile("../small_v11_ttbar_200406.root","READ");
-
-
-
 
 
   TFile * file = new TFile(input_file,"READ");
@@ -251,9 +247,7 @@ int main(){
     //R/Z Histograms
 
     TH2D * ROverZ_Inclusive = new TH2D("ROverZ_Inclusive","",42,0.076,0.58,12,0,2*M_PI/3);
-    //TH1D * ROverZ_Inclusive_Phi60 = new TH1D("ROverZ_Inclusive_Phi60","",42,0.076,0.58);
     std::map<std::tuple<int,int,int,int>,TH2D*> ROverZ_per_module;
-    //std::map<std::tuple<int,int,int,int>,TH1D*> ROverZ_per_module_Phi60;
     //Create one for each module (silicon at first)
     for ( int i = 0; i < 15; i++){//u
       for ( int j = 0; j < 15; j++){//v
@@ -261,8 +255,6 @@ int main(){
 
 	  if ( k < 28 && k%2 == 0 ) continue;
 	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH2D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,12,0,2*M_PI/3);
-	  //ROverZ_per_module_Phi60[std::make_tuple(0,i,j,k)] = new TH1D( ("ROverZ_Phi60_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
-	  
 	}
       }
     }
@@ -272,7 +264,6 @@ int main(){
 	for ( int k = 37; k < 53; k++){
 
 	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH2D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,12,0,2*M_PI/3);
-	  //ROverZ_per_module_Phi60[std::make_tuple(1,i,j,k)] = new TH1D( ("ROverZ_Phi60_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58);
 
 	}
       }
@@ -305,9 +296,6 @@ int main(){
 	std::pair<float,float> eta_phi = getROverZPhi(tc_x->at(j),tc_y->at(j),tc_z->at(j));
 	
 	ROverZ_Inclusive->Fill(std::abs(eta_phi.first),eta_phi.second);
-	// if ( eta_phi.second < M_PI/3 )
-	//   ROverZ_Inclusive_Phi60->Fill(std::abs(eta_phi.first));
-
 	
 	if ( u > -990 ){//Silicon
 	  std::pair<int,int> uv = std::make_pair(u,v);
@@ -320,11 +308,7 @@ int main(){
 	    per_event_minus.at(sector)->Fill(uv.first , uv.second, tc_layer->at(j) );
 	  }
 
-
 	  ROverZ_per_module[std::make_tuple(0,uv.first,uv.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first),eta_phi.second);
-	  // if ( eta_phi.second < M_PI/3 )
-	  //   ROverZ_per_module_Phi60[std::make_tuple(0,uv.first,uv.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
-	      
 	  
 	}
 	else{
@@ -340,12 +324,7 @@ int main(){
 	    per_event_minus_scin.at(sector)->Fill(etaphi.first , etaphi.second, tc_layer->at(j) );
 	  }
 
-
 	  ROverZ_per_module[std::make_tuple(1,etaphi.first,etaphi.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first),eta_phi.second);
-	  // if ( eta_phi.second < M_PI/3 )
-	  //   ROverZ_per_module_Phi60[std::make_tuple(1,etaphi.first,etaphi.second,tc_layer->at(j))]->Fill(std::abs(eta_phi.first));
-
-
 
 	}
 
@@ -462,17 +441,13 @@ int main(){
     TFile * file_out = new TFile("ROverZHistograms.root","RECREATE");
     file_out->cd();
     ROverZ_Inclusive->Write();
-    //    ROverZ_Inclusive_Phi60->Write();
 
     for (auto& x: ROverZ_per_module) {
       x.second->Write();
     }
-    // for (auto& x: ROverZ_per_module_Phi60) {
-    //   x.second->Write();
-    // }
 
     file_out->Close();
-    //out_words->SaveAs("hist.root");
+
     //Create output csv
     std::ofstream fout;
     fout.open ("average_tcs_sil.csv");

--- a/extract_data.cxx
+++ b/extract_data.cxx
@@ -151,6 +151,10 @@ std::pair<float,float> getEtaPhi(float x, float y, float z){
 }
 std::pair<float,float> getROverZPhi(float x, float y, float z){
 
+  if ( z < 0 ){
+    x *= -1;
+  }
+  
   float r = std::sqrt( x*x + y*y  );
   float phi = std::atan2(y,x);
 

--- a/plotbundles.py
+++ b/plotbundles.py
@@ -9,8 +9,8 @@ phi60_hists = []
 inclusive_hists_ratio = []
 phi60_hists_ratio = []
 
-inclusive = filein.Get("ROverZ_Inclusive")
-phi60 = filein.Get("ROverZ_Inclusive_Phi60")
+inclusive = filein.Get("ROverZ_Inclusive_1D")
+phi60 = filein.Get("ROverZ_Phi60")
 
 for i in range (24):
     inclusive_hists.append( filein.Get("lpgbt_ROverZ_bundled_"+str(i)+"_0") )

--- a/process.py
+++ b/process.py
@@ -7,7 +7,6 @@ import ROOT
 import time
 import itertools
 import random
-#import mlrose
 import sys
 from root_numpy import hist2array
 
@@ -87,7 +86,6 @@ def getModuleHists1D(HistFile):
             
     return inclusive_hists,module_hists
 
-#Legacy function to read ROverZHistograms file with 1D histograms
 def getModuleHists(HistFile):
 
     module_hists = []
@@ -106,27 +104,19 @@ def getModuleHists(HistFile):
                 
                 PhiVsROverZ = infiles[-1].Get("ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) )
                 inclusive[0,i,j,k] = PhiVsROverZ.ProjectionX( "ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) +"_Inclusive" )  
-                phi60[0,i,j,k] = PhiVsROverZ.ProjectionX( "ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) +"_Phi60", 1, 6)  #assuming 12 bins
+                #phi<60 is half the total number of bins in the y-dimension, i.e. for 12 bins (default) would be 6
+                nBinsPhi = PhiVsROverZ.GetNbinsY();
+                phi60[0,i,j,k] = PhiVsROverZ.ProjectionX( "ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) +"_Phi60", 1, nBinsPhi//2)                
 
-    # for i in range (15): #u
-    #     for j in range (15): #v
-    #         for k in range (53):#layer
-    #             if ( k < 28 and k%2 == 0 ):
-    #                 continue
-    #             phi60[0,i,j,k] = infiles[-1].Get("ROverZ_Phi60_silicon_"+str(i)+"_"+str(j)+"_"+str(k) )
 
     for i in range (5): #u
         for j in range (12): #v
             for k in range (37,53):#layer
                 PhiVsROverZ = infiles[-1].Get("ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) )
                 inclusive[1,i,j,k] =  PhiVsROverZ.ProjectionX( "ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) +"_Inclusive" )
-                phi60[1,i,j,k] =  PhiVsROverZ.ProjectionX( "ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) +"_Phi60", 1, 6) #assuming 12 bins
-
-    # for i in range (5): #u
-    #     for j in range (12): #v
-    #         for k in range (37,53):#layer
-    #             phi60[1,i,j,k] = infiles[-1].Get("ROverZ_Phi60_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) )
-
+                #phi<60 is half the total number of bins in the y-dimension, i.e. for 12 bins (default) would be 6
+                nBinsPhi = PhiVsROverZ.GetNbinsY();
+                phi60[1,i,j,k] =  PhiVsROverZ.ProjectionX( "ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) +"_Phi60", 1, nBinsPhi//2)
 
     
     PhiVsROverZ = infiles[-1].Get("ROverZ_Inclusive" )

--- a/process.py
+++ b/process.py
@@ -40,7 +40,8 @@ def getTCsPassing(CMSSW_Silicon,CMSSW_Scintillator):
 
     return data,data_scin
     
-def getModuleHists(HistFile):
+#Legacy function to read ROverZHistograms file with 1D histograms
+def getModuleHists1D(HistFile):
 
     module_hists = []
     inclusive_hists = []
@@ -80,6 +81,57 @@ def getModuleHists(HistFile):
 
     inclusive_hists.append(infiles[-1].Get("ROverZ_Inclusive" ))
     inclusive_hists.append(infiles[-1].Get("ROverZ_Inclusive_Phi60" ))
+                
+    module_hists.append(inclusive)
+    module_hists.append(phi60)
+            
+    return inclusive_hists,module_hists
+
+#Legacy function to read ROverZHistograms file with 1D histograms
+def getModuleHists(HistFile):
+
+    module_hists = []
+    inclusive_hists = []
+    
+    infiles.append(ROOT.TFile.Open(HistFile,"READ"))
+
+    inclusive = {}
+    phi60 = {}
+    
+    for i in range (15): #u
+        for j in range (15): #v
+            for k in range (53):#layer
+                if ( k < 28 and k%2 == 0 ):
+                    continue
+                
+                PhiVsROverZ = infiles[-1].Get("ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) )
+                inclusive[0,i,j,k] = PhiVsROverZ.ProjectionX( "ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) +"_Inclusive" )  
+                phi60[0,i,j,k] = PhiVsROverZ.ProjectionX( "ROverZ_silicon_"+str(i)+"_"+str(j)+"_"+str(k) +"_Phi60", 1, 6)  #assuming 12 bins
+
+    # for i in range (15): #u
+    #     for j in range (15): #v
+    #         for k in range (53):#layer
+    #             if ( k < 28 and k%2 == 0 ):
+    #                 continue
+    #             phi60[0,i,j,k] = infiles[-1].Get("ROverZ_Phi60_silicon_"+str(i)+"_"+str(j)+"_"+str(k) )
+
+    for i in range (5): #u
+        for j in range (12): #v
+            for k in range (37,53):#layer
+                PhiVsROverZ = infiles[-1].Get("ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) )
+                inclusive[1,i,j,k] =  PhiVsROverZ.ProjectionX( "ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) +"_Inclusive" )
+                phi60[1,i,j,k] =  PhiVsROverZ.ProjectionX( "ROverZ_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) +"_Phi60", 1, 6) #assuming 12 bins
+
+    # for i in range (5): #u
+    #     for j in range (12): #v
+    #         for k in range (37,53):#layer
+    #             phi60[1,i,j,k] = infiles[-1].Get("ROverZ_Phi60_scintillator_"+str(i)+"_"+str(j)+"_"+str(k) )
+
+
+    
+    PhiVsROverZ = infiles[-1].Get("ROverZ_Inclusive" )
+    inclusive_hists.append(PhiVsROverZ.ProjectionX( "ROverZ_Inclusive_1D") )
+    inclusive_hists.append(PhiVsROverZ.ProjectionX( "ROverZ_Phi60" , 1, 6) )
                 
     module_hists.append(inclusive)
     module_hists.append(phi60)


### PR DESCRIPTION
Update to provide more detailed phi information in the ROverZ histograms.

Previously two 1D histograms were provided per module, one inclusive in phi, and one for phi < 60 degrees.

Now a 2D histogram is provided, (phi vs R/Z) with a bin width in phi of 10 degrees (could be modified later).

The code should run exactly as previously by default, but now allows for additional development looking at the module phi.