### PR TITLE
Allow custom ROverZ binning

### DIFF
--- a/config/extract_data.json
+++ b/config/extract_data.json
@@ -6,5 +6,8 @@
     "average_tcs_sil": "average_tcs_sil_v11_relval_ttbar_20200625.csv",
     "average_tcs_scin": "average_tcs_scin_v11_relval_ttbar_20200625.csv",
     "configFileVersion": "TpgV7",
-    "createFlatFile": false
+    "createFlatFile": false,
+    "nROverZBins": 42,
+    "rOverZMin": 0.076,
+    "rOverZMax": 0.58
 }

--- a/config/fluctuations.yaml
+++ b/config/fluctuations.yaml
@@ -13,6 +13,11 @@ corrections:
   ldmToHdmCorrectionType: 'FixedOcc'
   nTCCorrectionFile: 'data/different_nTCs_linkMapping.txt'
 
+binningConfig:
+  nROverZBins: 42
+  rOverZMin: 0.076
+  rOverZMax: 0.58
+
 truncationConfig:
   option1:
     maxTCsA: 400

--- a/extract_data.cxx
+++ b/extract_data.cxx
@@ -250,6 +250,9 @@ int main(int argc, char **argv){
   std::string average_tcs_scin = config["average_tcs_scin"];
   std::string configFileVersion = config["configFileVersion"];
   bool createFlatFile = config["createFlatFile"];
+  int nROverZBins = config["nROverZBins"];
+  double rOverZMin = config["rOverZMin"];
+  double rOverZMax = config["rOverZMax"];
 
   int max_ieta = 2; //Definition of a scintillator module is different between V7 and TpgV7 mapping files 
   if ( configFileVersion == "V7" ){
@@ -323,7 +326,7 @@ int main(int argc, char **argv){
 
     //R/Z Histograms
 
-    TH2D * ROverZ_Inclusive = new TH2D("ROverZ_Inclusive","",42,0.076,0.58,nPhiBins,phiMin,phiMax);
+    TH2D * ROverZ_Inclusive = new TH2D("ROverZ_Inclusive","",nROverZBins,rOverZMin,rOverZMax,nPhiBins,phiMin,phiMax);
     std::map<std::tuple<int,int,int,int>,TH2D*> ROverZ_per_module;
 
     //Create one for each module (silicon at first)
@@ -332,7 +335,7 @@ int main(int argc, char **argv){
 	for ( int k = 1; k < 53; k++){//layer
 
 	  if ( k < 28 && k%2 == 0 ) continue;
-	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH2D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,nPhiBins,phiMin,phiMax);
+	  ROverZ_per_module[std::make_tuple(0,i,j,k)] = new TH2D( ("ROverZ_silicon_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",nROverZBins,rOverZMin,rOverZMax,nPhiBins,phiMin,phiMax);
 
 	}
       }
@@ -342,7 +345,7 @@ int main(int argc, char **argv){
       for ( int j = 0; j < 12; j++){
 	for ( int k = 37; k < 53; k++){
 
-	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH2D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",42,0.076,0.58,nPhiBins,phiMin,phiMax);
+	  ROverZ_per_module[std::make_tuple(1,i,j,k)] = new TH2D( ("ROverZ_scintillator_" + std::to_string(i) + "_" +  std::to_string(j) +"_"+ std::to_string(k)).c_str(),"",nROverZBins,rOverZMin,rOverZMax,nPhiBins,phiMin,phiMax);
 
 	}
       }

--- a/fluctuation.py
+++ b/fluctuation.py
@@ -561,7 +561,7 @@ def main():
         subconfig = config['checkFluctuations']
         if 'tcPtConfig' in subconfig.keys():
             tcPtConfig = subconfig['tcPtConfig']
-            
+
         checkFluctuations(initial_state=subconfig['initial_state'], cmsswNtuple=subconfig['cmsswNtuple'], mappingFile=subconfig['mappingFile'], outputName=subconfig['outputName'], tcPtConfig = tcPtConfig, correctionConfig = correctionConfig, phisplitConfig = subconfig['phisplit'], truncationConfig = truncationConfig, binningConfig = binningConfig, save_ntc_hists=subconfig['save_ntc_hists'],beginEvent = subconfig['beginEvent'], endEvent = subconfig['endEvent'])
 
     #Plotting functions

--- a/fluctuation.py
+++ b/fluctuation.py
@@ -26,11 +26,14 @@ def getMiniGroupHistsNumpy(module_hists, minigroups_modules):
     minigroup_hists_phidivisionX = {}
     minigroup_hists_phidivisionY = {}
 
+    #Get binning from module hists
+    example_hist = next(iter(module_hists[0].values()))
+    nROverZBins = len(example_hist)
 
     for minigroup, modules in minigroups_modules.items():
         
-        phidivisionX = np.zeros(42)
-        phidivisionY = np.zeros(42)
+        phidivisionX = np.zeros(nROverZBins)
+        phidivisionY = np.zeros(nROverZBins)
         
         for module in modules:
             phidivisionX = phidivisionX + module_hists[0][module[0],module[1],module[2],module[3]]
@@ -247,11 +250,20 @@ def applyTruncationAndGetPtSums(bundled_tc_Pt_rawdata,truncation_values, TCratio
     return alldata
 
 
-def checkFluctuations(initial_state, cmsswNtuple, mappingFile, outputName="alldata", tcPtConfig=None, correctionConfig=None, phisplitConfig=None, truncationConfig = None, save_ntc_hists=False, beginEvent = -1, endEvent = -1):
+def checkFluctuations(initial_state, cmsswNtuple, mappingFile, outputName="alldata", tcPtConfig=None, correctionConfig=None, phisplitConfig=None, truncationConfig = None, binningConfig = None, save_ntc_hists=False, beginEvent = -1, endEvent = -1):
 
-    nROverZBins = 42
+    if ( binningConfig != None ):        
+        nROverZBins = binningConfig["nROverZBins"]
+        rOverZMin = binningConfig["rOverZMin"]
+        rOverZMax = binningConfig["rOverZMax"]
+    else:
+        #Set defaults
+        nROverZBins = 42
+        rOverZMin = 0.076
+        rOverZMax = 0.58
+        
     #To get binning for r/z histograms
-    inclusive_hists = np.histogram( np.empty(0), bins = nROverZBins, range = (0.076,0.58) )
+    inclusive_hists = np.histogram( np.empty(0), bins = nROverZBins, range = (rOverZMin,rOverZMax) )
     roverzBinning = inclusive_hists[1]
     
     #List of which minigroups are assigned to each bundle 
@@ -446,17 +458,17 @@ def checkFluctuations(initial_state, cmsswNtuple, mappingFile, outputName="allda
             for key1,value1 in ROverZ_per_module_phidivisionX.items():
                 module_hists_phidivisionX[key1] = {}
                 for key2,value2 in value1.items():
-                    module_hists_phidivisionX[key1][key2] = np.histogram( value2, bins = nROverZBins, range = (0.076,0.58) )[0]
+                    module_hists_phidivisionX[key1][key2] = np.histogram( value2, bins = nROverZBins, range = (rOverZMin,rOverZMax) )[0]
 
             for key1,value1 in ROverZ_per_module_phidivisionY.items():
                 module_hists_phidivisionY[key1] = {}
                 for key2,value2 in value1.items():
-                    module_hists_phidivisionY[key1][key2] = np.histogram( value2, bins = nROverZBins, range = (0.076,0.58) )[0]
+                    module_hists_phidivisionY[key1][key2] = np.histogram( value2, bins = nROverZBins, range = (rOverZMin,rOverZMax) )[0]
 
             for z in (-1,1):
                 for sector in (0,1,2):
                         
-                    #the module hists are a numpy array of size 42
+                    #the module hists are a numpy array of size nROverZBins (42 by default)
                     module_hists = [module_hists_phidivisionX[z,sector],module_hists_phidivisionY[z,sector]]
                     
                     #Apply geometry corrections
@@ -536,6 +548,10 @@ def main():
     if 'truncationConfig' in config.keys():
         truncationConfig = config['truncationConfig']
 
+    binningConfig = None
+    if 'binningConfig' in config.keys():
+        binningConfig = config['binningConfig']
+
     if (config['function']['checkFluctuations']):
         correctionConfig = None
         if 'corrections' in config.keys():
@@ -545,26 +561,26 @@ def main():
         subconfig = config['checkFluctuations']
         if 'tcPtConfig' in subconfig.keys():
             tcPtConfig = subconfig['tcPtConfig']
-
-        checkFluctuations(initial_state=subconfig['initial_state'], cmsswNtuple=subconfig['cmsswNtuple'], mappingFile=subconfig['mappingFile'], outputName=subconfig['outputName'], tcPtConfig = tcPtConfig, correctionConfig = correctionConfig, phisplitConfig = subconfig['phisplit'], truncationConfig = truncationConfig, save_ntc_hists=subconfig['save_ntc_hists'],beginEvent = subconfig['beginEvent'], endEvent = subconfig['endEvent'])
+            
+        checkFluctuations(initial_state=subconfig['initial_state'], cmsswNtuple=subconfig['cmsswNtuple'], mappingFile=subconfig['mappingFile'], outputName=subconfig['outputName'], tcPtConfig = tcPtConfig, correctionConfig = correctionConfig, phisplitConfig = subconfig['phisplit'], truncationConfig = truncationConfig, binningConfig = binningConfig, save_ntc_hists=subconfig['save_ntc_hists'],beginEvent = subconfig['beginEvent'], endEvent = subconfig['endEvent'])
 
     #Plotting functions
     
     if (config['function']['plot_MeanMax']):
         subconfig = config['plot_MeanMax']
-        plotMeanMax(eventData = subconfig['eventData'], outdir = config['output_dir'], includePhi60 = subconfig['includePhi60'])
+        plotMeanMax(eventData = subconfig['eventData'], outdir = config['output_dir'], includePhi60 = subconfig['includePhi60'], binningConfig = binningConfig )
 
     if (config['function']['plot_Truncation']):
         subconfig = config['plot_Truncation']
-        plotTruncation(eventData = subconfig['eventData'],outdir = config['output_dir'], includePhi60 = subconfig['includePhi60'] )
+        plotTruncation(eventData = subconfig['eventData'],outdir = config['output_dir'], includePhi60 = subconfig['includePhi60'], binningConfig = binningConfig )
         
     if (config['function']['studyTruncationOptions']):
         subconfig = config['studyTruncationOptions']
-        studyTruncationOptions(eventData = subconfig['eventData'], options_to_study = subconfig['options_to_study'], truncation_values_method = subconfig['truncation_values_method'], truncationConfig = config['truncationConfig'], outdir = config['output_dir'] )
+        studyTruncationOptions(eventData = subconfig['eventData'], options_to_study = subconfig['options_to_study'], truncation_values_method = subconfig['truncation_values_method'], truncationConfig = config['truncationConfig'], binningConfig = binningConfig, outdir = config['output_dir'] )
         
     if (config['function']['plot_Truncation_tc_Pt']):
         subconfig = config['plot_Truncation_tc_Pt']
-        plot_Truncation_tc_Pt(eventData = subconfig['eventData'], options_to_study = subconfig['options_to_study'], truncationConfig = config['truncationConfig'], outdir = config['output_dir'] )
+        plot_Truncation_tc_Pt(eventData = subconfig['eventData'], options_to_study = subconfig['options_to_study'], truncationConfig = config['truncationConfig'], binningConfig = binningConfig, outdir = config['output_dir'] )
 
     
 main()

--- a/fluctuation_postprocess.py
+++ b/fluctuation_postprocess.py
@@ -13,15 +13,24 @@ import time
 import yaml
 import sys, os
 
-def plotMeanMax(eventData, outdir = ".", includePhi60 = True):
+def plotMeanMax(eventData, outdir = ".", includePhi60 = True, binningConfig = None):
     #Load pickled per-event bundle histograms
     with open(eventData, "rb") as filep:   
         bundled_lpgbthists_allevents = pickle.load(filep)
     os.system("mkdir -p " + outdir)
+
+    if ( binningConfig != None ):        
+        nROverZBins = binningConfig["nROverZBins"]
+        rOverZMin = binningConfig["rOverZMin"]
+        rOverZMax = binningConfig["rOverZMax"]
+    else:
+        #Set defaults
+        nROverZBins = 42
+        rOverZMin = 0.076
+        rOverZMax = 0.58
     
-    nbins = 42
     #To get binning for r/z histograms
-    inclusive_hists = np.histogram( np.empty(0), bins = nbins, range = (0.076,0.58) )
+    inclusive_hists = np.histogram( np.empty(0), bins = nROverZBins, range = (rOverZMin,rOverZMax) )
 
     #Names for inclusive and phi < 60 indices
     inclusive = 0
@@ -33,8 +42,8 @@ def plotMeanMax(eventData, outdir = ".", includePhi60 = True):
 
     for bundle in range(24):
 
-        list_over_events_inclusive = np.empty(((len(bundled_lpgbthists_allevents)),nbins))
-        list_over_events_phi60 = np.empty(((len(bundled_lpgbthists_allevents)),nbins))
+        list_over_events_inclusive = np.empty(((len(bundled_lpgbthists_allevents)),nROverZBins))
+        list_over_events_phi60 = np.empty(((len(bundled_lpgbthists_allevents)),nROverZBins))
         
         for e,event in enumerate(bundled_lpgbthists_allevents):
             list_over_events_inclusive[e] = np.array(event[inclusive][bundle])/6
@@ -124,7 +133,7 @@ def plot_NTCs_Vs_ROverZ(inputdata,axis,savename,truncation_curves=None,scaling=N
 
     #Plot the 2D histogram
     pl.clf()
-    pl.hist2d( roverz , data_swap.flatten() , bins = (len(axis)-1,50),range=[[0.076,0.58], [0, 50]],norm=LogNorm())
+    pl.hist2d( roverz , data_swap.flatten() , bins = (len(axis)-1,50),range=[[axis[0],axis[-1]], [0, 50]],norm=LogNorm())
     pl.colorbar().set_label("Number of Events")
     #Plot the various 1D truncation curves
     colours = ['red','orange','cyan','green','teal','darkviolet']
@@ -228,7 +237,7 @@ def getOptimalScalingValue(scalar,data):
 def getReverseTruncationValues( dataA, dataB, maxTCsA, maxTCsB ):
     #Obtain the truncation values by demanding that the efficiency be constant as a function of r/z
     
-    nbins = len(dataA[0][0]) #42
+    nbins = len(dataA[0][0]) #42 by default
 
     #Option to read out means
     print_means = True
@@ -346,7 +355,7 @@ def loadFluctuationData(eventData):
     dataY = 1
 
     nbundles = len(bundled_lpgbthists_allevents[0][0]) #24
-    nbins = len(bundled_lpgbthists_allevents[0][0][0]) #42
+    nbins = len(bundled_lpgbthists_allevents[0][0][0]) #42 by default
     
     dataX_bundled_lpgbthists_allevents = np.empty((len(bundled_lpgbthists_allevents),nbundles,nbins))
     dataY_bundled_lpgbthists_allevents = np.empty((len(bundled_lpgbthists_allevents),nbundles,nbins))
@@ -357,17 +366,25 @@ def loadFluctuationData(eventData):
 
     return dataX_bundled_lpgbthists_allevents, dataY_bundled_lpgbthists_allevents
     
-def studyTruncationOptions(eventData, options_to_study, truncation_values_method, truncationConfig, outdir = "."):
-    
+def studyTruncationOptions(eventData, options_to_study, truncation_values_method, truncationConfig, binningConfig = None, outdir = "."):
+
+    if ( binningConfig != None ):        
+        rOverZMin = binningConfig["rOverZMin"]
+        rOverZMax = binningConfig["rOverZMax"]
+    else:
+        #Set defaults
+        rOverZMin = 0.076
+        rOverZMax = 0.58
+
     #Load pickled per-event bundle histograms
     phidivisionX_bundled_lpgbthists_allevents,phidivisionY_bundled_lpgbthists_allevents = loadFluctuationData(eventData)
 
     os.system("mkdir -p " + outdir)
 
-    nbinsROverZ = len(phidivisionX_bundled_lpgbthists_allevents[0][0]) #42
+    nbinsROverZ = len(phidivisionX_bundled_lpgbthists_allevents[0][0]) #42 by default
     
     #To get binning for r/z histograms
-    inclusive_hists = np.histogram( np.empty(0), bins = nbinsROverZ, range = (0.076,0.58) )
+    inclusive_hists = np.histogram( np.empty(0), bins = nbinsROverZ, range = (rOverZMin, rOverZMax) )
 
     inclusive_bundled_lpgbthists_allevents = phidivisionX_bundled_lpgbthists_allevents + phidivisionY_bundled_lpgbthists_allevents
 
@@ -433,14 +450,24 @@ def studyTruncationOptions(eventData, options_to_study, truncation_values_method
         plot_frac_Vs_ROverZ( regionA, regionB, values, option['maxTCsA']/option['maxTCsB'], inclusive_hists[1], "Sum No. TCs Option " + str(study_num), outdir + "/frac_option_"+str(study_num))
 
 
-def plotTruncation(eventData, outdir = ".", includePhi60 = True):
+def plotTruncation(eventData, outdir = ".", includePhi60 = True, binningConfig = None):
     os.system("mkdir -p " + outdir)
+
+    if ( binningConfig != None ):        
+        nROverZBins = binningConfig["nROverZBins"]
+        rOverZMin = binningConfig["rOverZMin"]
+        rOverZMax = binningConfig["rOverZMax"]
+    else:
+        #Set defaults
+        nROverZBins = 42
+        rOverZMin = 0.076
+        rOverZMax = 0.58
     
     #Load pickled per-event bundle histograms
     phidivisionX_bundled_lpgbthists_allevents,phidivisionY_bundled_lpgbthists_allevents = loadFluctuationData(eventData)
 
     #To get binning for r/z histograms
-    inclusive_hists = np.histogram( np.empty(0), bins = 42, range = (0.076,0.58) )
+    inclusive_hists = np.histogram( np.empty(0), bins = nROverZBins, range = (rOverZMin,rOverZMax) )
     roverzBinning = inclusive_hists[1]
     
     #Form the intersection of the inclusive and phi60 arrays,
@@ -478,7 +505,7 @@ def plotTruncation(eventData, outdir = ".", includePhi60 = True):
 
         bundle_hists_inclusive = bundle_hists_phidivisionX + bundle_hists_phidivisionY
         bundle_hists_maximum = np.maximum(bundle_hists_inclusive,bundle_hists_phidivisionY*2)
-        #24 arrays, with length of 42        
+        #24 arrays, with length of nROverZBins (42 by default)
 
         sum99 = []
         sum95 = []
@@ -497,7 +524,7 @@ def plotTruncation(eventData, outdir = ".", includePhi60 = True):
             sum90.append ( np.where( np.less( overall_max90p, bundle ), overall_max90p, bundle )  )
         
 
-        total_per_event.append( np.sum(bundle_hists, axis=1 ))        #array with length of 24 (sum over the 42 bins)
+        total_per_event.append( np.sum(bundle_hists, axis=1 ))        #array with length of 24 (sum over the bins - 42 by default)
         total_per_event99.append( np.sum(sum99, axis=1 ))
         total_per_event95.append( np.sum(sum95, axis=1 ))
         total_per_event90.append( np.sum(sum90, axis=1 ))
@@ -550,8 +577,16 @@ def plotTruncation(eventData, outdir = ".", includePhi60 = True):
     pl.ylim((0,1100000))
     pl.savefig( outdir + "/phidivisionYIntegrated.png" )
 
-def plot_Truncation_tc_Pt(eventData, options_to_study, truncationConfig = None, outdir = ".",  ):
+def plot_Truncation_tc_Pt(eventData, options_to_study, truncationConfig = None, binningConfig = None, outdir = "."):
     os.system("mkdir -p " + outdir)
+    
+    if ( binningConfig != None ):        
+        rOverZMin = binningConfig["rOverZMin"]
+        rOverZMax = binningConfig["rOverZMax"]
+    else:
+        #Set defaults
+        rOverZMin = 0.076
+        rOverZMax = 0.58
     
     #Load the per-event flucation data produced using 'checkFluctuations'
     with open(eventData, "rb") as filep:   
@@ -563,8 +598,8 @@ def plot_Truncation_tc_Pt(eventData, options_to_study, truncationConfig = None, 
         for option in options_to_study:
             nLinks.append(truncationConfig['option'+str(option)]['nLinks'])
 
-    nbinsROverZ = len(data[0][0][0]) #42
-    axis =  np.histogram( np.empty(0), bins = nbinsROverZ, range = (0.076,0.58) )[1]
+    nbinsROverZ = len(data[0][0][0]) #42 by default
+    axis =  np.histogram( np.empty(0), bins = nbinsROverZ, range = (rOverZMin,rOverZMax) )[1]
 
     truncation_options_regionA = []
     truncation_options_regionB = []

--- a/fluctuation_postprocess.py
+++ b/fluctuation_postprocess.py
@@ -132,8 +132,9 @@ def plot_NTCs_Vs_ROverZ(inputdata,axis,savename,truncation_curves=None,scaling=N
     roverz = np.take(axis,axis_indices)
 
     #Plot the 2D histogram
+    nTCbins = int(50*(42/(len(axis)-1)))
     pl.clf()
-    pl.hist2d( roverz , data_swap.flatten() , bins = (len(axis)-1,50),range=[[axis[0],axis[-1]], [0, 50]],norm=LogNorm())
+    pl.hist2d( roverz , data_swap.flatten() , bins = (len(axis)-1,nTCbins),range=[[axis[0],axis[-1]], [0, nTCbins]],norm=LogNorm())
     pl.colorbar().set_label("Number of Events")
     #Plot the various 1D truncation curves
     colours = ['red','orange','cyan','green','teal','darkviolet']

--- a/plotbundles.py
+++ b/plotbundles.py
@@ -13,7 +13,13 @@ import matplotlib.pyplot as pl
 def print_numpy_plot(hists,outdir,plotname):
 
     os.system("mkdir -p " + outdir)
-    inclusive_hists = np.histogram( np.empty(0), bins = 42, range = (0.076,0.58) )
+
+    #Get binning from input hists
+    nROverZBins = hists[0].GetNbinsX()
+    rOverZMin = hists[0].GetXaxis().GetBinLowEdge(1)
+    rOverZMax = hists[0].GetXaxis().GetBinLowEdge(nROverZBins + 1)
+    
+    inclusive_hists = np.histogram( np.empty(0), bins = nROverZBins, range = (rOverZMin,rOverZMax) )
 
     numpy_hists = []
     for hist in hists:


### PR DESCRIPTION
A small update such that the ROverZ binning may be set from config files, and inferred from input distributions where necessary.

- Features
    - ROverZ binning set in the config files `extract_data.json` and `fluctuations.yaml`. Where needed otherwise it is inferred from input distributions such that everything is consistent.
    - The plot range of nTCs is automatically adjusted based on the binning.

- Bug fixes
     - None
     
- Other
     - None
  